### PR TITLE
feat: URLs accesibles y deep-linking por página

### DIFF
--- a/src/DashboardApp.tsx
+++ b/src/DashboardApp.tsx
@@ -30,9 +30,13 @@ import {
   canAccessSeguimientos,
 } from './lib/supabase';
 import { X, Upload, Phone, Info, Check, RefreshCw, Trash2, AlertTriangle } from 'lucide-react';
+import { useDashboardRoute, navigateDashboard } from './lib/dashboardRoute';
 
 function DashboardApp() {
-  const [currentPage, setCurrentPage] = React.useState<string>('dashboard');
+  // La URL es la fuente de verdad de la navegación (/dashboard/<page>[/<detailId>]).
+  const { page: currentPage, detailId } = useDashboardRoute();
+  // Navegar a una página equivale a cambiar la URL; el render se deriva de currentPage.
+  const goToPage = React.useCallback((p: string) => navigateDashboard(p), []);
   const [calls, setCalls] = React.useState<RetellCall[]>([]);
   const [filteredCalls, setFilteredCalls] = React.useState<RetellCall[]>([]);
   const [stats, setStats] = React.useState<CallStats | null>(null);
@@ -85,7 +89,7 @@ function DashboardApp() {
   React.useEffect(() => {
     if (currentPage === 'agendas' && !agendaEnabled) {
       // console.log('Agenda deshabilitada, redirigiendo al dashboard');
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, agendaEnabled]);
   
@@ -93,7 +97,7 @@ function DashboardApp() {
   React.useEffect(() => {
     if (currentPage === 'lanzamiento' && !launchEnabled) {
       // console.log('Sin permisos de lanzamiento, redirigiendo al dashboard');
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, launchEnabled]);
   
@@ -101,7 +105,7 @@ function DashboardApp() {
   React.useEffect(() => {
     if (currentPage === 'no-llamar' && !dontCallEnabled) {
       // console.log('Sin permisos de no-llamar, redirigiendo al dashboard');
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, dontCallEnabled]);
 
@@ -109,7 +113,7 @@ function DashboardApp() {
   React.useEffect(() => {
     if (currentPage === 'campaign' && !campaignEnabled) {
       // console.log('Sin permisos de campaña, redirigiendo al dashboard');
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, campaignEnabled]);
 
@@ -137,32 +141,32 @@ function DashboardApp() {
   }, []);
   React.useEffect(() => {
     if (currentPage === 'tickets' && !ticketsEnabled) {
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, ticketsEnabled]);
   React.useEffect(() => {
     if (currentPage === 'recoveries' && !recoveriesEnabled) {
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, recoveriesEnabled]);
   React.useEffect(() => {
     if (currentPage === 'interesados' && !hydroEnabled) {
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, hydroEnabled]);
   React.useEffect(() => {
     if (currentPage === 'soporte-ia' && !assistantIAEnabled) {
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, assistantIAEnabled]);
   React.useEffect(() => {
     if (currentPage === 'presupuesto' && !budgetEnabled) {
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, budgetEnabled]);
   React.useEffect(() => {
     if (currentPage === 'seguimientos' && !seguimientosEnabled) {
-      setCurrentPage('dashboard');
+      navigateDashboard('dashboard', undefined, { replace: true });
     }
   }, [currentPage, seguimientosEnabled]);
   
@@ -809,7 +813,10 @@ function DashboardApp() {
     const [loadingTasks, setLoadingTasks] = React.useState<boolean>(false);
     const [tasksError, setTasksError] = React.useState<string | null>(null);
     const [showTasksModal, setShowTasksModal] = React.useState<boolean>(false);
-    
+
+    // Deep-linking: el id del batch abierto vive en la URL (/dashboard/batch-call/<batch_call_id>)
+    const { detailId: batchDetailId } = useDashboardRoute();
+
     // Estado para el modal de confirmación de eliminación
     const [deleteConfirmModalOpen, setDeleteConfirmModalOpen] = React.useState<boolean>(false);
     const [batchToDelete, setBatchToDelete] = React.useState<RetellBatchCall | null>(null);
@@ -888,10 +895,24 @@ function DashboardApp() {
       setDeleteError(null);
     }, []);
     
-    // Función para cerrar el modal de tareas
+    // Función para cerrar el modal de tareas (quita el id de la URL; el efecto cierra el modal)
     const closeTasksModal = React.useCallback(() => {
-      setShowTasksModal(false);
+      navigateDashboard('batch-call');
     }, []);
+
+    // Sincronizar el modal de tareas con la URL (deep-link, atrás/adelante, recarga)
+    React.useEffect(() => {
+      if (batchDetailId && batchCallsLoaded) {
+        if (!selectedBatch || selectedBatch.batch_call_id !== batchDetailId) {
+          const batch = batchCalls.find((b) => b.batch_call_id === batchDetailId);
+          if (batch) loadBatchTasks(batch);
+        }
+      } else if (!batchDetailId && showTasksModal) {
+        setShowTasksModal(false);
+        setSelectedBatch(null);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [batchDetailId, batchCallsLoaded, batchCalls]);
 
     // Función para formatear timestamp a fecha legible
     const formatDate = React.useCallback((timestamp: number) => {
@@ -1075,7 +1096,7 @@ function DashboardApp() {
                       <tr 
                         key={batch.batch_call_id} 
                         className="border-b border-gray-800 hover:bg-gray-800/50 cursor-pointer"
-                        onClick={() => loadBatchTasks(batch)}
+                        onClick={() => navigateDashboard('batch-call', batch.batch_call_id)}
                       >
                         <td className="p-3 text-white font-medium">{batch.name}</td>
                         <td className="p-3">
@@ -1295,7 +1316,7 @@ function DashboardApp() {
     <div className="min-h-screen bg-gray-50">
       <Sidebar 
         currentPage={currentPage} 
-        onPageChange={setCurrentPage} 
+        onPageChange={goToPage}
         cacheStatus={cacheStatus}
         isLoading={loading || loadingAllCalls}
       />
@@ -1327,29 +1348,29 @@ function DashboardApp() {
         )}
         {currentPage === 'recordings' && (
           <Recordings 
-            onNavigate={setCurrentPage as (page: 'dashboard' | 'recordings') => void}
+            onNavigate={goToPage}
           />
         )}
         {currentPage === 'phones' && (
           <PhoneNumbers
-            onNavigate={setCurrentPage as (page: 'dashboard' | 'recordings' | 'phones') => void}
+            onNavigate={goToPage}
           />
         )}
         {currentPage === 'agendas' && agendaEnabled && (
           <Agendas
-            onNavigate={setCurrentPage as (page: string) => void}
+            onNavigate={goToPage}
           />
         )}
         {currentPage === 'callbacks' && (
           <Callbacks
-            onNavigate={setCurrentPage as (page: string) => void}
+            onNavigate={goToPage}
           />
         )}
         {currentPage === 'batch-call' && (
-          <BatchCall onNavigate={setCurrentPage as (page: string) => void} />
+          <BatchCall onNavigate={goToPage} />
         )}
         {currentPage === 'ventas' && (
-          <Ventas onNavigate={setCurrentPage as (page: string) => void} />
+          <Ventas onNavigate={goToPage} />
         )}
         {currentPage === 'lanzamiento' && (
           <Lanzamiento />
@@ -1358,16 +1379,16 @@ function DashboardApp() {
           <NoLlamar />
         )}
         {currentPage === 'tickets' && ticketsEnabled && (
-          <Tickets onNavigate={setCurrentPage as (page: string) => void} />
+          <Tickets onNavigate={goToPage} />
         )}
         {currentPage === 'recoveries' && recoveriesEnabled && (
-          <Recoveries onNavigate={setCurrentPage as (page: string) => void} />
+          <Recoveries onNavigate={goToPage} />
         )}
         {currentPage === 'interesados' && hydroEnabled && (
-          <Interesados onNavigate={setCurrentPage as (page: string) => void} />
+          <Interesados onNavigate={goToPage} />
         )}
         {currentPage === 'campaign' && campaignEnabled && (
-          <Campaign onNavigate={setCurrentPage as (page: string) => void} />
+          <Campaign onNavigate={goToPage} />
         )}
         {currentPage === 'soporte-ia' && !assistantIAEnabled && (
           <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-6 text-center text-amber-900 text-sm max-w-md">
@@ -1376,13 +1397,13 @@ function DashboardApp() {
           </div>
         )}
         {currentPage === 'soporte-ia' && assistantIAEnabled && (
-          <SoporteIA onNavigate={setCurrentPage as (page: string) => void} />
+          <SoporteIA onNavigate={goToPage} />
         )}
         {currentPage === 'presupuesto' && budgetEnabled && (
-          <Presupuesto onNavigate={setCurrentPage as (page: string) => void} />
+          <Presupuesto onNavigate={goToPage} />
         )}
         {currentPage === 'seguimientos' && seguimientosEnabled && (
-          <Seguimientos onNavigate={setCurrentPage as (page: string) => void} />
+          <Seguimientos onNavigate={goToPage} />
         )}
         </Suspense>
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -320,28 +320,11 @@ export function Sidebar({
     setShowBatchCall(callType === "outbound");
   }, []);
 
-  // Función para mantener los parámetros URL al cambiar de página
+  // Cambiar de página. onPageChange (=navigateDashboard en DashboardApp) actualiza
+  // la URL a /dashboard/<page> conservando los query params; el render se deriva de ahí.
   const navigateWithParams = (page: string) => {
-    // Obtener y mantener los parámetros URL actuales
-    const currentUrl = new URL(window.location.href);
-    const searchParams = currentUrl.searchParams;
-
-    // Crear un objeto con todos los parámetros actuales
-    const params: Record<string, string> = {};
-    searchParams.forEach((value, key) => {
-      params[key] = value;
-    });
-
-    // Cambiar la página pero conservar los parámetros de URL
     onPageChange(page);
     setIsMobileMenuOpen(false);
-
-    // Actualizar la URL con los parámetros pero sin recargar la página
-    const newUrl = new URL(window.location.origin + window.location.pathname);
-    Object.entries(params).forEach(([key, value]) => {
-      newUrl.searchParams.append(key, value);
-    });
-    window.history.pushState({}, "", newUrl.toString());
   };
 
   // Truncar la API key para mostrarla de forma segura

--- a/src/lib/dashboardRoute.ts
+++ b/src/lib/dashboardRoute.ts
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+
+// Capa de sincronización URL <-> estado de navegación del dashboard.
+// La URL es la fuente de verdad: /dashboard/<page>[/<detailId>]
+// El estado de React (currentPage, modales) la espeja.
+
+// Ids de página válidos. Coinciden con los usados en el render condicional de
+// DashboardApp.tsx. Si la URL trae un page id desconocido, se cae a 'dashboard'.
+export const PAGE_IDS = [
+  'dashboard',
+  'recordings',
+  'phones',
+  'agendas',
+  'callbacks',
+  'batch-call',
+  'campaign',
+  'ventas',
+  'lanzamiento',
+  'no-llamar',
+  'tickets',
+  'recoveries',
+  'interesados',
+  'soporte-ia',
+  'presupuesto',
+  'seguimientos',
+] as const;
+
+export type PageId = (typeof PAGE_IDS)[number];
+
+// Evento que se dispara tras una navegación programática (history.pushState no
+// emite 'popstate' por sí mismo, así que notificamos a los suscriptores aquí).
+const NAVIGATE_EVENT = 'dashboard:navigate';
+
+export interface DashboardRoute {
+  page: string;
+  detailId: string | null;
+}
+
+// Parsea /dashboard/<page>/<detailId?> a partir del pathname.
+export function parseRoute(pathname: string): DashboardRoute {
+  const segments = pathname.split('/').filter(Boolean); // ['dashboard', '<page>', '<id>']
+
+  // Si no empieza por /dashboard, no es una ruta gestionada aquí.
+  if (segments[0] !== 'dashboard') {
+    return { page: 'dashboard', detailId: null };
+  }
+
+  const rawPage = segments[1];
+  const page = rawPage && (PAGE_IDS as readonly string[]).includes(rawPage) ? rawPage : 'dashboard';
+
+  // El detailId solo aplica si la página es válida (evita interpretar basura).
+  const detailId = page === rawPage && segments[2] ? decodeURIComponent(segments[2]) : null;
+
+  return { page, detailId };
+}
+
+// Construye /dashboard/<page>[/<detailId>] conservando el query string actual.
+export function buildPath(page: string, detailId?: string | null): string {
+  let path = `/dashboard/${page}`;
+  if (detailId != null && detailId !== '') {
+    path += `/${encodeURIComponent(detailId)}`;
+  }
+  const search = typeof window !== 'undefined' ? window.location.search : '';
+  return path + search;
+}
+
+// Navega de forma programática conservando los query params y notificando a los
+// suscriptores de useDashboardRoute.
+export function navigateDashboard(
+  page: string,
+  detailId?: string | null,
+  options?: { replace?: boolean }
+): void {
+  const path = buildPath(page, detailId);
+
+  // No-op si ya estamos en esa URL (evita entradas duplicadas en el historial).
+  if (path === window.location.pathname + window.location.search) {
+    return;
+  }
+
+  if (options?.replace) {
+    window.history.replaceState({}, '', path);
+  } else {
+    window.history.pushState({}, '', path);
+  }
+  window.dispatchEvent(new CustomEvent(NAVIGATE_EVENT));
+}
+
+// Hook reactivo: devuelve { page, detailId } y se actualiza ante carga inicial,
+// deep-link, atrás/adelante (popstate) y navegación programática (NAVIGATE_EVENT).
+export function useDashboardRoute(): DashboardRoute {
+  const [route, setRoute] = useState<DashboardRoute>(() =>
+    parseRoute(typeof window !== 'undefined' ? window.location.pathname : '/dashboard')
+  );
+
+  useEffect(() => {
+    const sync = () => setRoute(parseRoute(window.location.pathname));
+    window.addEventListener('popstate', sync);
+    window.addEventListener(NAVIGATE_EVENT, sync);
+    // Re-sincronizar al montar por si la URL cambió antes de suscribirnos.
+    sync();
+    return () => {
+      window.removeEventListener('popstate', sync);
+      window.removeEventListener(NAVIGATE_EVENT, sync);
+    };
+  }, []);
+
+  return route;
+}

--- a/src/pages/Agendas.tsx
+++ b/src/pages/Agendas.tsx
@@ -11,6 +11,7 @@ import {
 } from "../api";
 import { Agenda } from "../types";
 import { useCallsContext } from "../context/CallsContext";
+import { useDashboardRoute, navigateDashboard } from "../lib/dashboardRoute";
 import { AGENDAS_PAGE_SIZE } from "../lib/constants";
 import { toast } from "sonner";
 import {
@@ -90,6 +91,8 @@ export function Agendas({ onNavigate }: AgendasProps) {
   >("list");
   const [selectedAgenda, setSelectedAgenda] = useState<Agenda | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
+  // Deep-linking: la agenda abierta vive en la URL (/dashboard/agendas/<id>)
+  const { detailId } = useDashboardRoute();
   const [exporting, setExporting] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [agendaToDelete, setAgendaToDelete] = useState<Agenda | null>(null);
@@ -624,17 +627,32 @@ export function Agendas({ onNavigate }: AgendasProps) {
     setSortOrder("DESC");
   };
 
-  // Abrir modal con agenda seleccionada
+  // Abrir/cerrar el modal navegando: la URL es la fuente de verdad y el efecto
+  // de abajo sincroniza el estado del modal con el id de la URL.
   const openAgendaModal = (agenda: Agenda) => {
-    setSelectedAgenda(agenda);
-    setModalOpen(true);
+    navigateDashboard("agendas", String(agenda.id));
   };
 
-  // Cerrar modal
   const closeAgendaModal = () => {
-    setModalOpen(false);
-    setSelectedAgenda(null);
+    navigateDashboard("agendas");
   };
+
+  // Sincronizar el modal con la URL (deep-link, atrás/adelante, recarga)
+  useEffect(() => {
+    if (detailId) {
+      if (!selectedAgenda || String(selectedAgenda.id) !== detailId) {
+        const agenda = agendas.find((a) => String(a.id) === detailId);
+        if (agenda) {
+          setSelectedAgenda(agenda);
+          setModalOpen(true);
+        }
+      }
+    } else if (modalOpen) {
+      setModalOpen(false);
+      setSelectedAgenda(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailId, agendas]);
 
   // Abrir modal de confirmación de eliminación
   const openDeleteModal = (agenda: Agenda, e?: React.MouseEvent) => {

--- a/src/pages/Recordings.tsx
+++ b/src/pages/Recordings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Play, Pause, Download, Clock, ChevronDown, ChevronUp, Search, X, Phone, ChevronLeft, ChevronRight, ListFilter, PhoneOff, RefreshCw, PhoneCall, Plus, User, Send, CalendarDays } from 'lucide-react';
 import type { DetailedRetellCall, FilterCriteria, RetellAgent, RetellPhoneNumber } from '../types';
 import { useCallsContext } from '../context/CallsContext';
+import { useDashboardRoute, navigateDashboard } from '../lib/dashboardRoute';
 import { Button } from "../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { listCalls, exportCallsWithColumns, fetchAgents, createPhoneCall, getCallTranscript, getAudioUrl } from '../api';
@@ -552,6 +553,8 @@ function RecallModal({ call, onClose, apiKey, apiKeyTest, phoneNumbers }: Recall
 export function Recordings({ onNavigate }: RecordingsProps) {
 
   const [selectedCallModal, setSelectedCallModal] = React.useState<DetailedRetellCall | null>(null);
+  // Deep-linking: la grabación abierta vive en la URL (/dashboard/recordings/<call_id>)
+  const { detailId } = useDashboardRoute();
   const [recallCall, setRecallCall] = React.useState<DetailedRetellCall | null>(null);
   const [selectedCall, setSelectedCall] = React.useState<string | null>(null);
   const [playingId, setPlayingId] = React.useState<string | null>(null);
@@ -1132,8 +1135,18 @@ export function Recordings({ onNavigate }: RecordingsProps) {
     }
   }, [selectedCallModal, modalCallForTransition]);
 
-  // Modal functionality
+  // Abrir/cerrar el modal navegando: la URL es la fuente de verdad y el efecto
+  // de abajo aplica el estado (applyCallModal) según el call_id de la URL.
   const openCallModal = (call: DetailedRetellCall) => {
+    navigateDashboard('recordings', call.call_id);
+  };
+
+  const closeCallModal = () => {
+    navigateDashboard('recordings');
+  };
+
+  // Lógica real de apertura (estado + reproductor de audio), disparada por la URL.
+  const applyCallModal = (call: DetailedRetellCall) => {
     setSelectedCallModal(call);
     setSelectedCall(call.call_id);
 
@@ -1180,10 +1193,19 @@ export function Recordings({ onNavigate }: RecordingsProps) {
     }
   };
 
-  const closeCallModal = () => {
-    setSelectedCallModal(null);
-    setSelectedCall(null);
-  };
+  // Sincronizar el modal con la URL (deep-link, atrás/adelante, recarga)
+  React.useEffect(() => {
+    if (detailId) {
+      if (selectedCallModal?.call_id !== detailId) {
+        const call = filteredCalls.find((c) => c.call_id === detailId);
+        if (call) applyCallModal(call);
+      }
+    } else if (selectedCallModal) {
+      setSelectedCallModal(null);
+      setSelectedCall(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailId, filteredCalls]);
 
   const togglePlayPauseModal = () => {
     if (selectedCallModal) {

--- a/src/pages/SoporteIA.tsx
+++ b/src/pages/SoporteIA.tsx
@@ -33,6 +33,7 @@ import {
   Loader2,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
+import { useDashboardRoute, navigateDashboard } from '../lib/dashboardRoute';
 
 type SeccionSoporteIA = 'incidencias' | 'fichas';
 
@@ -387,6 +388,8 @@ export function SoporteIA({ onNavigate: _onNavigate }: SoporteIAProps) {
   const [pagNum, setPagNum] = useState(1);
   const [selectedFila, setSelectedFila] = useState<ZinkeeRegistroFila | null>(null);
   const [detalleOpen, setDetalleOpen] = useState(false);
+  // Deep-linking: el registro abierto vive en la URL (/dashboard/soporte-ia/<id>)
+  const { detailId } = useDashboardRoute();
 
   const campoById = useMemo(() => {
     const m = new Map<number, ZinkeeCampo>();
@@ -469,10 +472,27 @@ export function SoporteIA({ onNavigate: _onNavigate }: SoporteIAProps) {
     }));
   }, [campoById, seccion]);
 
+  // Abrir navegando: la URL manda y el efecto de abajo aplica el estado.
   const abrirDetalle = (fila: ZinkeeRegistroFila) => {
-    setSelectedFila(fila);
-    setDetalleOpen(true);
+    navigateDashboard('soporte-ia', String(fila.id));
   };
+
+  // Sincronizar el detalle con la URL (deep-link, atrás/adelante, recarga)
+  useEffect(() => {
+    if (detailId) {
+      if (!selectedFila || String(selectedFila.id) !== detailId) {
+        const fila = filas.find((f) => String(f.id) === detailId);
+        if (fila) {
+          setSelectedFila(fila);
+          setDetalleOpen(true);
+        }
+      }
+    } else if (detalleOpen) {
+      setDetalleOpen(false);
+      setSelectedFila(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailId, filas]);
 
   return (
     <div className="w-full min-w-0 max-w-full">
@@ -683,8 +703,8 @@ export function SoporteIA({ onNavigate: _onNavigate }: SoporteIAProps) {
       <RegistroDetalleDialog
         open={detalleOpen}
         onOpenChange={(o) => {
-          setDetalleOpen(o);
-          if (!o) setSelectedFila(null);
+          // Cerrar quita el id de la URL; el efecto sincroniza el estado.
+          if (!o) navigateDashboard('soporte-ia');
         }}
         fila={selectedFila}
         campoById={campoById}

--- a/src/pages/Tickets.tsx
+++ b/src/pages/Tickets.tsx
@@ -2,6 +2,7 @@
 import { createTicket, deleteTicket, fetchTickets, updateTicket } from '../api';
 import { Ticket } from '../types';
 import { useCallsContext } from '../context/CallsContext';
+import { useDashboardRoute, navigateDashboard } from '../lib/dashboardRoute';
 import { AlertCircle, ClipboardList, Pencil, RefreshCw, Send, Trash2 } from 'lucide-react';
 import { Button } from '../components/ui/button';
 
@@ -17,6 +18,8 @@ export function Tickets({ onNavigate: _onNavigate }: TicketsProps) {
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [deleteConfirmTicket, setDeleteConfirmTicket] = useState<Ticket | null>(null);
   const [editingTicket, setEditingTicket] = useState<Ticket | null>(null);
+  // Deep-linking: el ticket abierto vive en la URL (/dashboard/tickets/<id>)
+  const { detailId } = useDashboardRoute();
   const [editForm, setEditForm] = useState({ title: '', description: '', responsible: '', state: '' });
   const [savingId, setSavingId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -102,20 +105,36 @@ export function Tickets({ onNavigate: _onNavigate }: TicketsProps) {
     }
   };
 
+  // Abrir/cerrar navegando: la URL manda y el efecto de abajo aplica el estado.
   const handleEditOpen = (ticket: Ticket) => {
-    setEditingTicket(ticket);
-    setEditForm({
-      title: ticket.title,
-      description: ticket.description,
-      responsible: ticket.responsible,
-      state: ticket.state || 'Pendiente',
-    });
+    navigateDashboard('tickets', String(ticket.id));
   };
 
   const handleEditClose = () => {
-    setEditingTicket(null);
-    setEditForm({ title: '', description: '', responsible: '', state: '' });
+    navigateDashboard('tickets');
   };
+
+  // Sincronizar el modal de edición con la URL (deep-link, atrás/adelante, recarga)
+  useEffect(() => {
+    if (detailId) {
+      if (!editingTicket || String(editingTicket.id) !== detailId) {
+        const ticket = tickets.find((t) => String(t.id) === detailId);
+        if (ticket) {
+          setEditingTicket(ticket);
+          setEditForm({
+            title: ticket.title,
+            description: ticket.description,
+            responsible: ticket.responsible,
+            state: ticket.state || 'Pendiente',
+          });
+        }
+      }
+    } else if (editingTicket) {
+      setEditingTicket(null);
+      setEditForm({ title: '', description: '', responsible: '', state: '' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailId, tickets]);
 
   const handleEditSave = async (e: FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
Añade una capa de sincronización URL<->estado: la navegación pasa a reflejarse en la ruta (/dashboard/<page>) y el detalle abierto queda en la URL (/dashboard/<page>/<id>), permitiendo recarga, enlaces directos y atrás/adelante del navegador.

- Nuevo src/lib/dashboardRoute.ts (parseRoute/buildPath/navigateDashboard
  + hook useDashboardRoute suscrito a popstate y navegación programática).
- DashboardApp deriva currentPage de la URL; Sidebar simplificado.
- Deep-linking con id en Agendas, Recordings, Tickets, SoporteIA y BatchCalls (patrón URL-driven: abrir/cerrar navega, un efecto sincroniza el modal).